### PR TITLE
Add sensor platform to UniFi Access integration

### DIFF
--- a/homeassistant/components/unifi_access/__init__.py
+++ b/homeassistant/components/unifi_access/__init__.py
@@ -15,6 +15,7 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.EVENT,
+    Platform.SENSOR,
     Platform.SWITCH,
 ]
 

--- a/homeassistant/components/unifi_access/coordinator.py
+++ b/homeassistant/components/unifi_access/coordinator.py
@@ -195,15 +195,9 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
             updates["door_lock_relay_status"] = "unlock"
 
         if ws_state.remain_lock is not None:
-            new_lock_rule = DoorLockRuleStatus(
-                type=ws_state.remain_lock.type,
-                ended_time=ws_state.remain_lock.until,
-            )
+            new_lock_rule = ws_state.remain_lock.to_door_lock_rule_status()
         elif ws_state.remain_unlock is not None:
-            new_lock_rule = DoorLockRuleStatus(
-                type=ws_state.remain_unlock.type,
-                ended_time=ws_state.remain_unlock.until,
-            )
+            new_lock_rule = ws_state.remain_unlock.to_door_lock_rule_status()
         else:
             new_lock_rule = DoorLockRuleStatus()
         if new_lock_rule != current_door.lock_rule_status:

--- a/homeassistant/components/unifi_access/coordinator.py
+++ b/homeassistant/components/unifi_access/coordinator.py
@@ -12,7 +12,9 @@ from unifi_access_api import (
     ApiAuthError,
     ApiConnectionError,
     ApiError,
+    ApiNotFoundError,
     Door,
+    DoorLockRuleStatus,
     EmergencyStatus,
     UnifiAccessApiClient,
     WsMessageHandler,
@@ -55,6 +57,7 @@ class UnifiAccessData:
 
     doors: dict[str, Door]
     emergency: EmergencyStatus
+    supports_lock_rules: bool = True
 
 
 class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
@@ -123,9 +126,26 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
             raise UpdateFailed(f"Error communicating with API: {err}") from err
         except TimeoutError as err:
             raise UpdateFailed("Timeout communicating with UniFi Access API") from err
+
+        supports_lock_rules = True
+        try:
+            async with asyncio.timeout(10):
+                lock_rules = await asyncio.gather(
+                    *(self.client.get_door_lock_rule(door.id) for door in doors)
+                )
+            doors = [
+                door.with_updates(lock_rule_status=rule)
+                for door, rule in zip(doors, lock_rules)
+            ]
+        except ApiNotFoundError:
+            supports_lock_rules = False
+        except (ApiAuthError, ApiConnectionError, ApiError, TimeoutError) as err:
+            _LOGGER.debug("Could not fetch door lock rules: %s", err)
+
         return UnifiAccessData(
             doors={door.id: door for door in doors},
             emergency=emergency,
+            supports_lock_rules=supports_lock_rules,
         )
 
     def _on_ws_connect(self) -> None:
@@ -173,6 +193,22 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
             updates["door_lock_relay_status"] = "lock"
         elif ws_state.lock == "unlocked":
             updates["door_lock_relay_status"] = "unlock"
+
+        if ws_state.remain_lock is not None:
+            new_lock_rule = DoorLockRuleStatus(
+                type=ws_state.remain_lock.type,
+                ended_time=ws_state.remain_lock.until,
+            )
+        elif ws_state.remain_unlock is not None:
+            new_lock_rule = DoorLockRuleStatus(
+                type=ws_state.remain_unlock.type,
+                ended_time=ws_state.remain_unlock.until,
+            )
+        else:
+            new_lock_rule = DoorLockRuleStatus()
+        if new_lock_rule != current_door.lock_rule_status:
+            updates["lock_rule_status"] = new_lock_rule
+
         if not updates:
             return
         updated_door = current_door.with_updates(**updates)
@@ -180,6 +216,7 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
             UnifiAccessData(
                 doors={**self.data.doors, door_id: updated_door},
                 emergency=self.data.emergency,
+                supports_lock_rules=self.data.supports_lock_rules,
             )
         )
 
@@ -195,6 +232,7 @@ class UnifiAccessCoordinator(DataUpdateCoordinator[UnifiAccessData]):
                     evacuation=update.data.evacuation,
                     lockdown=update.data.lockdown,
                 ),
+                supports_lock_rules=self.data.supports_lock_rules,
             )
         )
 

--- a/homeassistant/components/unifi_access/sensor.py
+++ b/homeassistant/components/unifi_access/sensor.py
@@ -52,10 +52,10 @@ class UnifiAccessDoorLockRuleSensor(UnifiAccessEntity, SensorEntity):
     @property
     def native_value(self) -> str | None:
         """Return the active lock rule type, or None if no rule is active."""
-        rule_type = self._door.lock_rule_status.type
-        if rule_type is DoorLockRuleType.NONE:
+        rule_status = self._door.lock_rule_status
+        if rule_status is None or rule_status.type is DoorLockRuleType.NONE:
             return None
-        return rule_type.value
+        return rule_status.type.value
 
 
 class UnifiAccessDoorLockRuleEndTimeSensor(UnifiAccessEntity, SensorEntity):
@@ -76,7 +76,7 @@ class UnifiAccessDoorLockRuleEndTimeSensor(UnifiAccessEntity, SensorEntity):
     @property
     def native_value(self) -> datetime | None:
         """Return the time when the lock rule expires, or None if no rule is active."""
-        ended_time = self._door.lock_rule_status.ended_time
-        if ended_time == 0:
+        rule_status = self._door.lock_rule_status
+        if rule_status is None or rule_status.ended_time == 0:
             return None
-        return datetime.fromtimestamp(ended_time, tz=UTC)
+        return datetime.fromtimestamp(rule_status.ended_time, tz=UTC)

--- a/homeassistant/components/unifi_access/sensor.py
+++ b/homeassistant/components/unifi_access/sensor.py
@@ -1,0 +1,82 @@
+"""Sensor platform for the UniFi Access integration."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from unifi_access_api import Door, DoorLockRuleType
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import UnifiAccessConfigEntry, UnifiAccessCoordinator
+from .entity import UnifiAccessEntity
+
+PARALLEL_UPDATES = 0
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: UnifiAccessConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    """Set up UniFi Access sensor entities."""
+    coordinator = entry.runtime_data
+    if coordinator.data.supports_lock_rules:
+        async_add_entities(
+            sensor_class(coordinator, door)
+            for door in coordinator.data.doors.values()
+            for sensor_class in (
+                UnifiAccessDoorLockRuleSensor,
+                UnifiAccessDoorLockRuleEndTimeSensor,
+            )
+        )
+
+
+class UnifiAccessDoorLockRuleSensor(UnifiAccessEntity, SensorEntity):
+    """Sensor reporting the current lock rule for a UniFi Access door."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "door_lock_rule"
+
+    def __init__(
+        self,
+        coordinator: UnifiAccessCoordinator,
+        door: Door,
+    ) -> None:
+        """Initialize the lock rule sensor."""
+        super().__init__(coordinator, door, "lock_rule")
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the active lock rule type, or None if no rule is active."""
+        rule_type = self._door.lock_rule_status.type
+        if rule_type is DoorLockRuleType.NONE:
+            return None
+        return rule_type.value
+
+
+class UnifiAccessDoorLockRuleEndTimeSensor(UnifiAccessEntity, SensorEntity):
+    """Sensor reporting when the current lock rule expires."""
+
+    _attr_device_class = SensorDeviceClass.TIMESTAMP
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_translation_key = "door_lock_rule_ended_time"
+
+    def __init__(
+        self,
+        coordinator: UnifiAccessCoordinator,
+        door: Door,
+    ) -> None:
+        """Initialize the lock rule end time sensor."""
+        super().__init__(coordinator, door, "lock_rule_ended_time")
+
+    @property
+    def native_value(self) -> datetime | None:
+        """Return the time when the lock rule expires, or None if no rule is active."""
+        ended_time = self._door.lock_rule_status.ended_time
+        if ended_time == 0:
+            return None
+        return datetime.fromtimestamp(ended_time, tz=UTC)

--- a/homeassistant/components/unifi_access/strings.json
+++ b/homeassistant/components/unifi_access/strings.json
@@ -59,6 +59,23 @@
       "lockdown": {
         "name": "Lockdown"
       }
+    },
+    "sensor": {
+      "door_lock_rule": {
+        "name": "Door Lock Rule",
+        "state": {
+          "custom": "Custom",
+          "keep_lock": "Locked",
+          "keep_unlock": "Unlocked",
+          "lock_early": "Lock Early",
+          "lock_now": "Lock Now",
+          "reset": "Reset",
+          "schedule": "Schedule"
+        }
+      },
+      "door_lock_rule_ended_time": {
+        "name": "Rule End Time"
+      }
     }
   },
   "exceptions": {

--- a/tests/components/unifi_access/conftest.py
+++ b/tests/components/unifi_access/conftest.py
@@ -9,6 +9,7 @@ import pytest
 from unifi_access_api import (
     Door,
     DoorLockRelayStatus,
+    DoorLockRuleStatus,
     DoorPositionStatus,
     EmergencyStatus,
 )
@@ -99,6 +100,7 @@ def mock_client() -> Generator[MagicMock]:
         client.get_emergency_status = AsyncMock(
             return_value=EmergencyStatus(evacuation=False, lockdown=False)
         )
+        client.get_door_lock_rule = AsyncMock(return_value=DoorLockRuleStatus())
         client.set_emergency_status = AsyncMock()
         client.unlock_door = AsyncMock()
         client.close = AsyncMock()

--- a/tests/components/unifi_access/snapshots/test_sensor.ambr
+++ b/tests/components/unifi_access/snapshots/test_sensor.ambr
@@ -1,0 +1,203 @@
+# serializer version: 1
+# name: test_sensor_entities[sensor.back_door_door_lock_rule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.back_door_door_lock_rule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Door Lock Rule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Door Lock Rule',
+    'platform': 'unifi_access',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'door_lock_rule',
+    'unique_id': 'door-002-lock_rule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities[sensor.back_door_door_lock_rule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Back Door Door Lock Rule',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.back_door_door_lock_rule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'keep_lock',
+  })
+# ---
+# name: test_sensor_entities[sensor.back_door_rule_end_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.back_door_rule_end_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Rule End Time',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Rule End Time',
+    'platform': 'unifi_access',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'door_lock_rule_ended_time',
+    'unique_id': 'door-002-lock_rule_ended_time',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities[sensor.back_door_rule_end_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Back Door Rule End Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.back_door_rule_end_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-14T22:13:20+00:00',
+  })
+# ---
+# name: test_sensor_entities[sensor.front_door_door_lock_rule-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.front_door_door_lock_rule',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Door Lock Rule',
+    'options': dict({
+    }),
+    'original_device_class': None,
+    'original_icon': None,
+    'original_name': 'Door Lock Rule',
+    'platform': 'unifi_access',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'door_lock_rule',
+    'unique_id': 'door-001-lock_rule',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities[sensor.front_door_door_lock_rule-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'friendly_name': 'Front Door Door Lock Rule',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.front_door_door_lock_rule',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': 'keep_lock',
+  })
+# ---
+# name: test_sensor_entities[sensor.front_door_rule_end_time-entry]
+  EntityRegistryEntrySnapshot({
+    'aliases': list([
+      None,
+    ]),
+    'area_id': None,
+    'capabilities': None,
+    'config_entry_id': <ANY>,
+    'config_subentry_id': <ANY>,
+    'device_class': None,
+    'device_id': <ANY>,
+    'disabled_by': None,
+    'domain': 'sensor',
+    'entity_category': <EntityCategory.DIAGNOSTIC: 'diagnostic'>,
+    'entity_id': 'sensor.front_door_rule_end_time',
+    'has_entity_name': True,
+    'hidden_by': None,
+    'icon': None,
+    'id': <ANY>,
+    'labels': set({
+    }),
+    'name': None,
+    'object_id_base': 'Rule End Time',
+    'options': dict({
+    }),
+    'original_device_class': <SensorDeviceClass.TIMESTAMP: 'timestamp'>,
+    'original_icon': None,
+    'original_name': 'Rule End Time',
+    'platform': 'unifi_access',
+    'previous_unique_id': None,
+    'suggested_object_id': None,
+    'supported_features': 0,
+    'translation_key': 'door_lock_rule_ended_time',
+    'unique_id': 'door-001-lock_rule_ended_time',
+    'unit_of_measurement': None,
+  })
+# ---
+# name: test_sensor_entities[sensor.front_door_rule_end_time-state]
+  StateSnapshot({
+    'attributes': ReadOnlyDict({
+      'device_class': 'timestamp',
+      'friendly_name': 'Front Door Rule End Time',
+    }),
+    'context': <ANY>,
+    'entity_id': 'sensor.front_door_rule_end_time',
+    'last_changed': <ANY>,
+    'last_reported': <ANY>,
+    'last_updated': <ANY>,
+    'state': '2023-11-14T22:13:20+00:00',
+  })
+# ---

--- a/tests/components/unifi_access/test_sensor.py
+++ b/tests/components/unifi_access/test_sensor.py
@@ -1,0 +1,184 @@
+"""Tests for the UniFi Access sensor platform."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from syrupy.assertion import SnapshotAssertion
+from unifi_access_api import ApiNotFoundError, DoorLockRuleStatus, DoorLockRuleType
+from unifi_access_api.models.websocket import (
+    LocationUpdateData,
+    LocationUpdateState,
+    LocationUpdateV2,
+    WebsocketMessage,
+    WsDoorLockRuleStatus,
+)
+
+from homeassistant.const import Platform
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+
+from . import setup_integration
+
+from tests.common import MockConfigEntry, snapshot_platform
+
+FRONT_DOOR_LOCK_RULE_ENTITY = "sensor.front_door_door_lock_rule"
+FRONT_DOOR_LOCK_RULE_END_TIME_ENTITY = "sensor.front_door_rule_end_time"
+BACK_DOOR_LOCK_RULE_ENTITY = "sensor.back_door_door_lock_rule"
+BACK_DOOR_LOCK_RULE_END_TIME_ENTITY = "sensor.back_door_rule_end_time"
+
+
+def _get_ws_handlers(
+    mock_client: MagicMock,
+) -> dict[str, Callable[[WebsocketMessage], Awaitable[None]]]:
+    """Extract WebSocket handlers from mock client."""
+    return mock_client.start_websocket.call_args[0][0]
+
+
+async def test_sensor_entities(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+    entity_registry: er.EntityRegistry,
+    snapshot: SnapshotAssertion,
+) -> None:
+    """Test sensor entities are created with expected state."""
+    mock_client.get_door_lock_rule = AsyncMock(
+        return_value=DoorLockRuleStatus(
+            type=DoorLockRuleType.KEEP_LOCK, ended_time=1700000000
+        )
+    )
+    with patch(
+        "homeassistant.components.unifi_access.PLATFORMS", [Platform.SENSOR]
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    await snapshot_platform(hass, entity_registry, snapshot, mock_config_entry.entry_id)
+
+
+async def test_sensor_lock_rule_state(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test sensor states reflect lock rule values."""
+    mock_client.get_door_lock_rule = AsyncMock(
+        return_value=DoorLockRuleStatus(
+            type=DoorLockRuleType.KEEP_LOCK, ended_time=1700000000
+        )
+    )
+    with patch(
+        "homeassistant.components.unifi_access.PLATFORMS", [Platform.SENSOR]
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_ENTITY).state == "keep_lock"
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_END_TIME_ENTITY).state == (
+        datetime.fromtimestamp(1700000000, tz=UTC).isoformat()
+    )
+
+
+async def test_sensor_no_active_rule(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test sensor state is unknown when no lock rule is active."""
+    mock_client.get_door_lock_rule = AsyncMock(return_value=DoorLockRuleStatus())
+    with patch(
+        "homeassistant.components.unifi_access.PLATFORMS", [Platform.SENSOR]
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_ENTITY).state == "unknown"
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_END_TIME_ENTITY).state == "unknown"
+
+
+async def test_sensor_not_created_when_lock_rules_unsupported(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test that sensor entities are not created when lock rules are unsupported."""
+    mock_client.get_door_lock_rule = AsyncMock(side_effect=ApiNotFoundError)
+    with patch(
+        "homeassistant.components.unifi_access.PLATFORMS", [Platform.SENSOR]
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_ENTITY) is None
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_END_TIME_ENTITY) is None
+
+
+async def test_sensor_lock_rule_websocket_update(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test lock rule sensor updates via websocket."""
+    mock_client.get_door_lock_rule = AsyncMock(return_value=DoorLockRuleStatus())
+    with patch(
+        "homeassistant.components.unifi_access.PLATFORMS", [Platform.SENSOR]
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_ENTITY).state == "unknown"
+
+    handlers = _get_ws_handlers(mock_client)
+    update_msg = LocationUpdateV2(
+        event="access.data.device.location_update_v2",
+        data=LocationUpdateData(
+            id="door-001",
+            location_type="DOOR",
+            state=LocationUpdateState(
+                remain_lock=WsDoorLockRuleStatus(
+                    type=DoorLockRuleType.KEEP_LOCK,
+                    until=1700000000,
+                )
+            ),
+        ),
+    )
+    await handlers["access.data.device.location_update_v2"](update_msg)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_ENTITY).state == "keep_lock"
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_END_TIME_ENTITY).state == (
+        datetime.fromtimestamp(1700000000, tz=UTC).isoformat()
+    )
+
+
+async def test_sensor_lock_rule_websocket_rule_cleared(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+    mock_client: MagicMock,
+) -> None:
+    """Test lock rule sensor clears when websocket reports no active rule."""
+    mock_client.get_door_lock_rule = AsyncMock(
+        return_value=DoorLockRuleStatus(
+            type=DoorLockRuleType.KEEP_LOCK, ended_time=1700000000
+        )
+    )
+    with patch(
+        "homeassistant.components.unifi_access.PLATFORMS", [Platform.SENSOR]
+    ):
+        await setup_integration(hass, mock_config_entry)
+
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_ENTITY).state == "keep_lock"
+
+    handlers = _get_ws_handlers(mock_client)
+    update_msg = LocationUpdateV2(
+        event="access.data.device.location_update_v2",
+        data=LocationUpdateData(
+            id="door-001",
+            location_type="DOOR",
+            state=LocationUpdateState(),
+        ),
+    )
+    await handlers["access.data.device.location_update_v2"](update_msg)
+    await hass.async_block_till_done()
+
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_ENTITY).state == "unknown"
+    assert hass.states.get(FRONT_DOOR_LOCK_RULE_END_TIME_ENTITY).state == "unknown"


### PR DESCRIPTION
## Proposed change

Add a `sensor` platform to the UniFi Access integration with two diagnostic sensor entities per door:

- **Door Lock Rule** (`sensor.<door>_door_lock_rule`): reports the active temporary lock rule type (`keep_lock`, `keep_unlock`, `custom`, etc.). Returns `unknown` when no rule is active.
- **Rule End Time** (`sensor.<door>_rule_end_time`): `TIMESTAMP` device class sensor reporting when the active lock rule expires.

Sensors are only registered when the controller supports lock rules (older controllers return 404 and sensors are skipped entirely).

Lock rule state is fetched from the REST API on initial load and kept up to date via websocket `location_update_v2` / `access.data.v2.location.update` messages using the `remain_lock` / `remain_unlock` fields.

## Type of change

- New integration feature (new platform in existing integration)

## Checklist

- [x] The code change is tested and working locally
- [x] Tests have been added to verify correct operation (`tests/components/unifi_access/test_sensor.py`)
- [x] Snapshot tests updated